### PR TITLE
Update to bevy 0.8 and fix some panics in loader_system

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,25 @@
+# Add the contents of this file to `config.toml` to enable "fast build" configuration. Please read the notes below.
+
+# NOTE: For maximum performance, build using a nightly compiler
+# If you are using rust stable, remove the "-Zshare-generics=y" below.
+
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
+
+# NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
+# `brew install michaeleisel/zld/zld`
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/zld", "-Zshare-generics=y"]
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"
+rustflags = ["-Zshare-generics=n"]
+
+# Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
+# In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
+#[profile.dev]
+#debug = 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 Cargo.lock
 **/target
+.idea
+tmp
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,19 @@ authors = ["Duncan <bonsairobo@gmail.com>"]
 edition = "2021"
 
 [workspace]
+resolver = "2"
 members = ["crates/*"]
 exclude = ["archived", "benches"]
 
 [profile]
-dev = { opt-level = 2 }
 release = { lto = "thin" }
 bench = { lto = "thin" }
+
+[profile.dev]
+opt-level = 2
+
+[profile.dev.package."*"]
+opt-level = 3
 
 [[bin]]
 name = "viewer"
@@ -28,10 +34,11 @@ feldspar-core = { path = "crates/feldspar-core", version = "0.1" }
 feldspar-map = { path = "crates/feldspar-map", version = "0.1", features = ["bevy_plugin"] }
 feldspar-renderer = { path = "crates/feldspar-renderer", version = "0.1" }
 
-smooth-bevy-cameras = { git = "https://github.com/bonsairobo/smooth-bevy-cameras", rev = "383de21c" }
+[dependencies.smooth-bevy-cameras]
+git = "https://github.com/bonsairobo/smooth-bevy-cameras"
+rev = "a1095b9bc563d459c79b59e12ef620fa4567e04e"
 
 [dependencies.bevy]
-git = "https://github.com/bevyengine/bevy"
-rev = "fc0f15f1"
+version = "0.8.0"
 default-features = false
-features = ["render", "png", "x11"]
+features = ["render", "png", "x11", "dynamic", "bevy_asset"]

--- a/bin/viewer/main.rs
+++ b/bin/viewer/main.rs
@@ -1,10 +1,9 @@
 use bevy::{
     pbr::wireframe::{WireframeConfig, WireframePlugin},
     prelude::*,
-    render::{options::WgpuOptions, render_resource::WgpuFeatures},
+    render::{settings::WgpuSettings, settings::WgpuFeatures},
 };
 use feldspar_map::MapPlugin;
-use feldspar_renderer::RenderPlugin;
 use smooth_bevy_cameras::{
     controllers::fps::{FpsCameraBundle, FpsCameraController, FpsCameraPlugin},
     LookTransformPlugin,
@@ -17,11 +16,10 @@ fn main() {
         title: "Feldspar Map Viewer".to_string(),
         ..Default::default()
     };
-
     App::new()
         // Bevy
         .insert_resource(window_desc)
-        .insert_resource(WgpuOptions {
+        .insert_resource(WgpuSettings {
             features: WgpuFeatures::POLYGON_MODE_LINE,
             ..Default::default()
         })
@@ -30,7 +28,7 @@ fn main() {
         .add_plugin(WireframePlugin)
         // Feldspar
         .add_plugin(MapPlugin::default())
-        .add_plugin(RenderPlugin)
+        // .add_plugin(RenderPlugin)
         // Viewer
         .add_plugin(LookTransformPlugin)
         .add_plugin(FpsCameraPlugin::default())
@@ -54,7 +52,6 @@ fn setup(mut commands: Commands, mut wireframe_config: ResMut<WireframeConfig>) 
     let target = Vec3::new(0.0, 0.0, 0.0);
     commands.spawn_bundle(FpsCameraBundle::new(
         FpsCameraController::default(),
-        PerspectiveCameraBundle::default(),
         eye,
         target,
     ));

--- a/crates/feldspar-map/Cargo.toml
+++ b/crates/feldspar-map/Cargo.toml
@@ -29,10 +29,10 @@ futures-lite = { version = "1.12", optional = true }
 
 # Optional; enable to get the Bevy plugin.
 [dependencies.bevy]
-git = "https://github.com/bevyengine/bevy"
-rev = "fc0f15f1"
+version = "0.8.0"
 default-features = false
 optional = true
+features = ["dynamic"]
 
 [dev-dependencies]
 crossbeam = "0.8"

--- a/crates/feldspar-map/src/plugin.rs
+++ b/crates/feldspar-map/src/plugin.rs
@@ -2,6 +2,7 @@ mod config;
 mod loader;
 mod witness;
 
+use std::sync::Arc;
 pub use config::MapConfig;
 pub use loader::LoaderConfig;
 pub use witness::Witness;
@@ -9,7 +10,11 @@ pub use witness::Witness;
 use loader::loader_system;
 use witness::witness_system;
 
-use bevy::prelude::{CoreStage, Plugin};
+use bevy::prelude::{Commands, CoreStage, Plugin, Res};
+use bevy::tasks::{IoTaskPool, TaskPoolBuilder};
+use crate::clipmap::ChunkClipMap;
+use crate::database::MapDb;
+use crate::plugin::loader::PendingLoadTasks;
 
 #[derive(Default)]
 pub struct MapPlugin {
@@ -25,7 +30,27 @@ impl MapPlugin {
 impl Plugin for MapPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.insert_resource(self.config.clone())
+            .add_startup_system(plugin_startup)
             .add_system_to_stage(CoreStage::Update, loader_system)
             .add_system_to_stage(CoreStage::Last, witness_system);
     }
+}
+
+fn plugin_startup(mut commands: Commands, config: Res<MapConfig>) {
+    let db = sled::Config::default()
+        .path("tmp".to_owned())
+        .use_compression(false)
+        .mode(sled::Mode::LowSpace)
+        .open()
+        .expect("Failed to open world DB");
+
+    let mapdb = MapDb::open(&db, "main").expect("Failed to load main level");
+    commands.insert_resource(
+        Arc::new(mapdb)
+    );
+    let chunk_clip_map = ChunkClipMap::new(config.num_lods, config.streaming);
+    commands.insert_resource(chunk_clip_map);
+
+    let task_pool = PendingLoadTasks::new();
+    commands.insert_resource(task_pool);
 }

--- a/crates/feldspar-map/src/plugin/loader.rs
+++ b/crates/feldspar-map/src/plugin/loader.rs
@@ -38,10 +38,18 @@ pub struct PendingLoadTasks {
     tasks: VecDeque<Task<LoadedBatch>>,
 }
 
+impl PendingLoadTasks {
+    pub fn new() -> Self {
+        PendingLoadTasks {
+            tasks: VecDeque::new()
+        }
+    }
+}
+
 pub fn loader_system(
     config: Res<MapConfig>,
     witness_transforms: Query<(&Witness, &Transform)>,
-    io_pool: Res<IoTaskPool>,
+    // io_pool: Res<IoTaskPool>,
     db: Res<Arc<MapDb>>, // PERF: better option than Arc?
     mut clipmap: ResMut<ChunkClipMap>,
     mut load_tasks: ResMut<PendingLoadTasks>,
@@ -82,6 +90,7 @@ pub fn loader_system(
 
             // Spawn a new task to load those nodes.
             let db_clone = db.clone();
+            let io_pool = IoTaskPool::get();
             let load_task = io_pool.spawn(async move {
                 // PERF: Should this batch be a single task?
                 LoadedBatch {

--- a/crates/feldspar-renderer/Cargo.toml
+++ b/crates/feldspar-renderer/Cargo.toml
@@ -11,7 +11,6 @@ feldspar-map = { path = "../feldspar-map/", version = "0.1", features = ["bevy"]
 fast-surface-nets = "0.1"
 
 [dependencies.bevy]
-git = "https://github.com/bevyengine/bevy"
-rev = "fc0f15f1"
+version = "0.8.0"
 default-features = false
-features = ["render", "png", "x11"]
+features = ["render", "png", "x11", "dynamic"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Most of the changes are in commit `db7ca3a`:

Updating to 0.8 mostly consisted of fixing some import statements and
updating some structs to their new name. There is now a startup system
that the feldspar-map bevy plugin adds that initializes and inserts the resources into
the bevy app. I also changed to the rust nightly compiler, set up the
ldd linker and enabled bevy dynamic linking to speed up compile times as
per the bevy startup guide.

The code now compiles and is able to run without panics but that other than that still just shows a black screen.